### PR TITLE
include Arduino.h->arduino.h for case sensitive FS

### DIFF
--- a/Jamrules
+++ b/Jamrules
@@ -37,7 +37,7 @@ rule Ino
 
 actions Ino
 {
-  echo "#include <Arduino.h>" > $(<) 
+  echo "#include <arduino.h>" > $(<) 
   echo "#line 1 \"$(>)\"" >> $(<)
   cat $(>) >> $(<) 
 }


### PR DESCRIPTION
On Case sensitive file systems the include Arduino.h does not point to the correct include.
Use arduino.h instead
